### PR TITLE
Fixed link to book's website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Gren Programming Language
 
-This repo contains the source code of "The Gren Programming Language", available to read from [gren-lang.org](https://book.gren-lang.org).
+This repo contains the source code of "The Gren Programming Language", available to read from [gren-lang.org](https://gren-lang.org/book/).
 
 ## Development
 


### PR DESCRIPTION
I noticed the link to the book's website seemed incorrect (I am unable to resolve the old URL from a number of hosts) so I've changed the URL to point to the same location that the Gren home page links to.