### PR TITLE
Expand custom type and pattern matching pages

### DIFF
--- a/src/content/docs/syntax/custom_types.md
+++ b/src/content/docs/syntax/custom_types.md
@@ -8,12 +8,87 @@ Sometimes it's helpful to have values that can be in one of several states. This
 In Gren, this concept is known as custom types.
 
 ```elm
+type MyResult
+    = Success
+    | Failure
+```
+
+This means a `MyResult` value can be one of two things (called variants): a `Success` or a `Failure`.
+You can call your type and your variants anything you want, as long as they start with a capital letter.
+
+Try entering the above into a `gren repl`.
+Then you can create values using the variant names:
+
+```elm frame=terminal
+> result1 = Success
+Success : MyResult
+> result2 = Failure
+Failure : MyResult
+```
+
+## Types with Data
+
+Custom types can also hold data.
+
+Let's say you want to fetch your repo's star count from the Github API.
+Here is a type that could hold the result of that fetch:
+
+```elm
+type StarCount
+    = Count Int
+    | Error String
+```
+
+A `StarCount` value could either be a successful fetch holding the resulting count, or a failed fetch holding an error message.
+
+When you create values using your variant names, you're actually calling functions that gren created for you:
+
+```elm frame=terminal
+> Count
+<function> : Int -> StarCount
+> Error
+<function> : String -> StarCount
+```
+
+That means you can pass in the data like you would for any other function:
+
+```elm frame=terminal
+> count1 = Count 123
+Count 123 : StarCount
+> count2 = Error "Oops! Fetch failed."
+Error ("Oops! Fetch failed.") : StarCount
+```
+
+## Type Variables
+
+You can define custom types that hold any type of data by using a type variable.
+A common example is a type built-in to gren called `Maybe`.
+
+```elm
 type Maybe a
     = Just a
     | Nothing
 ```
 
-The type `Maybe` can be one of two things. Either it's `Just a` where `a` is a generic type, or it's `Nothing` in which case there is no associated data attached.
+Here `a` is a type variable and could have been any word starting with a lowercase letter.
+So `Maybe` can be one of two things: Either it's `Just a` where `a` is a generic type for whatever data its holding, or it's `Nothing` in which case there is no associated data attached.
 
-On its own, custom types aren't very helpful, but in combination with pattern matching they allow for some pretty interesting possibilities.
+```elm frame=terminal
+> Just "Hello"
+Just "Hello" : Maybe String
+```
+
+Notice that Gren inferred the generic type here as the concrete type `String`.
+
+You can have more than one type variable.
+Gren's built-in `Result` type has a variable for the error value and one for the success value.
+
+```elm
+type Result error value
+    = Ok value
+    | Err error
+```
+
+But how do you get that data out of the custom type?
+One way is with pattern matching, which allows for some pretty interesting possibilities when combined with custom types.
 

--- a/src/content/docs/syntax/pattern_matching.md
+++ b/src/content/docs/syntax/pattern_matching.md
@@ -3,22 +3,39 @@ title: Pattern Matching
 description: Pattern matching in Gren
 ---
 
-When dealing with custom types, you likely want to do different things based on the actual value of the custom type. The `case of` expression provides this flexibility.
+When dealing with [custom types](/book/syntax/custom_types/), you likely want to do different things based on the actual value of the custom type. The `case of` expression provides this flexibility.
 
 ```elm
-explainHeldItem : Maybe String -> String
-explainHeldItem maybeItem =
-    case maybeItem of
-        Nothing ->
-          "You're not holding anything"
+type Role
+  = Viewer
+  | Editor
+  | Admin
 
-        Just item ->
-          "You're holding a " ++ item
+canEdit : Role -> Bool
+canEdit role =
+    case role of
+        Viewer ->
+            False
+        
+        Editor ->
+            True
+        
+        Admin ->
+            True
+```
 
+In gren, pattern matching is exhaustive.
+That means the compiler will complain if you don't cover all possible cases.
+This is very helpful, since you can add a variant to your custom type without worrying that you forgot to handle it somewhere.
 
-holdingSword : String
-holdingSword =
-    explainHeldItem (Just "Sword")
+If you don't need to handle all possible cases explicitly, you can use `_` as a catch-all:
+
+```elm
+canAddUser : Role -> Bool
+canAddUser role =
+    case role of
+        Admin -> True
+        _ -> False
 ```
 
 You can use pattern matching on other things than just custom types. Like integers:
@@ -48,3 +65,45 @@ combineIngredients left right =
             , quantity = left.quantity + right.quantity
             }
 ```
+
+## Patterns with Data
+
+You can use pattern matching to extract nested data from your values.
+
+If you have a [custom type with data](/book/syntax/custom_types/#types-with-data), you can give that data a name and use it in the branch for that pattern:
+
+```elm
+explainHeldItem : Maybe String -> String
+explainHeldItem maybeItem =
+    case maybeItem of
+        Nothing ->
+          "You're not holding anything"
+
+        Just item ->
+          "You're holding a " ++ item
+
+
+holdingSword : String
+holdingSword =
+    explainHeldItem (Just "Sword")
+```
+
+You can get data from other types of values as well:
+
+```elm
+run : Array String -> String
+run args =
+    case args of
+        [] ->
+           "No arguments provided."
+            
+        [ "greet", name ] ->
+            "Hello, " ++ name ++ "!"
+        
+        [ "flip", first, second ] ->
+            second ++ first 
+            
+        _ ->
+          "Unrecognized arguments."
+```
+


### PR DESCRIPTION
This explains some concepts that were only included implicitly in the examples, like destructuring and the `_` case. And adds concepts that weren't covered at all, like exhaustiveness.