### PR TITLE
Fix mix of tabs and spaces in astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,44 +11,44 @@ export default defineConfig({
       title: 'The Gren Programming Language',
       favicon: '/favicon.png',
       social: {
-				github: 'https://github.com/gren-lang/book',
-				mastodon: 'https://fosstodon.org/@gren_lang',
-			},
-			sidebar: [
-				{
-					label: 'Introduction',
-					items: [
-						{ label: 'Why Gren', link: '/' },
-						{ label: 'Hello World', link: '/hello_world/' },
-					],
-				},
-			  {
-					label: 'The Language',
-					items: [
-						{ label: 'Getting started', link: '/syntax/repl/' },
-						{ label: 'Constants', link: '/syntax/constants/' },
-						{ label: 'Functions', link: '/syntax/functions/' },
-						{ label: 'Numbers', link: '/syntax/numbers/' },
-						{ label: 'Arrays', link: '/syntax/arrays/' },
-						{ label: 'Strings', link: '/syntax/strings/' },
+        github: 'https://github.com/gren-lang/book',
+        mastodon: 'https://fosstodon.org/@gren_lang',
+      },
+      sidebar: [
+        {
+          label: 'Introduction',
+          items: [
+            { label: 'Why Gren', link: '/' },
+            { label: 'Hello World', link: '/hello_world/' },
+          ],
+        },
+        {
+          label: 'The Language',
+          items: [
+            { label: 'Getting started', link: '/syntax/repl/' },
+            { label: 'Constants', link: '/syntax/constants/' },
+            { label: 'Functions', link: '/syntax/functions/' },
+            { label: 'Numbers', link: '/syntax/numbers/' },
+            { label: 'Arrays', link: '/syntax/arrays/' },
+            { label: 'Strings', link: '/syntax/strings/' },
             { label: 'Records', link: '/syntax/records/' },
-						{ label: 'Types', link: '/syntax/types/' },
-						{ label: 'If expressions', link: '/syntax/ifs/' },
-						{ label: 'Let expressions', link: '/syntax/lets/' },
-						{ label: 'Custom types', link: '/syntax/custom_types/' },
-						{ label: 'Pattern matching', link: '/syntax/pattern_matching/' },
-						{ label: 'Destructuring', link: '/syntax/destructuring/' },
-						{ label: 'Modules', link: '/syntax/modules/' },
-						{ label: 'Comments', link: '/syntax/comments/' },
-					],
-				},
-				{
-					label: 'Appendix',
-					items: [
-						{ label: 'gren.json', link: '/appendix/gren_json/' },
-						{ label: 'FAQ', link: '/appendix/faq/' },
-					],
-				},
+            { label: 'Types', link: '/syntax/types/' },
+            { label: 'If expressions', link: '/syntax/ifs/' },
+            { label: 'Let expressions', link: '/syntax/lets/' },
+            { label: 'Custom types', link: '/syntax/custom_types/' },
+            { label: 'Pattern matching', link: '/syntax/pattern_matching/' },
+            { label: 'Destructuring', link: '/syntax/destructuring/' },
+            { label: 'Modules', link: '/syntax/modules/' },
+            { label: 'Comments', link: '/syntax/comments/' },
+          ],
+        },
+        {
+          label: 'Appendix',
+          items: [
+            { label: 'gren.json', link: '/appendix/gren_json/' },
+            { label: 'FAQ', link: '/appendix/faq/' },
+          ],
+        },
       ],
     }),
   ]


### PR DESCRIPTION
Some lines used tabs, some used spaces. Normalized to spaces since that is what the rest of the files use.