### PR TITLE
Expand on the Gren Runtime

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,8 +53,8 @@ export default defineConfig({
         {
           label: 'Applications',
           items: [
-            { label: 'The Gren Runtime', link: '/applications/runtime/' },
             { label: 'The Elm Architecture', link: '/applications/tea/' },
+            { label: 'The Gren Runtime', link: '/applications/runtime/' },
             { label: 'Browser Applications', link: '/applications/browser/' },
             { label: 'Node Applications', link: '/applications/node/' },
             { label: 'Commands', link: '/applications/commands/' },

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b?lastModified=1742707865&narHash=sha256-RVQQZy38O3Zb8yoRJhuFgWo%2FiDIDj0hEdRTVfhOtzRk%3D"
+    },
     "nodejs@20": {
       "last_modified": "2024-11-03T14:18:04Z",
       "plugin_version": "0.0.2",

--- a/src/content/docs/applications/runtime.md
+++ b/src/content/docs/applications/runtime.md
@@ -34,7 +34,7 @@ are values representing an _effect_ you want to perform.
 You can think of an effect as something that doesn't conform to the three properties of Gren code described above:
 - It could fail (like reading from local storage or making an HTTP call)
 - It could change something (like writing to the file system or updating a database)
-- It won't _always_ result in the same value (like reading a file or querying a database)
+- It won't _always_ result in the same value (like reading a file or querying a database), or it might not result in any value at all!
 
 [Subscriptions](https://packages.gren-lang.org/package/gren-lang/core/version/latest/module/Platform.Sub)
 are values that let you tell the Gren runtime that you want to be notified when something happens.

--- a/src/content/docs/applications/runtime.md
+++ b/src/content/docs/applications/runtime.md
@@ -57,6 +57,6 @@ flowchart LR
 
 - Your `init` function initializes your model when the application starts, but it can also send a command to the runtime if you need an effect right at the start.
 - Your `update` function is the only place you will receive messages from the Gren runtime. In addition to updating the model, you can also kick off new commands in response to the messages you receive.
-- Your `subscriptions` lets you tell the runtime about certainjevents you want to receive messages about.
+- Your `subscriptions` function lets you tell the runtime about certain events you want to receive messages about.
   
 In the next sections you will see what this looks like in practice.

--- a/src/content/docs/applications/runtime.md
+++ b/src/content/docs/applications/runtime.md
@@ -56,7 +56,8 @@ flowchart LR
 ```
 
 - Your `init` function initializes your model when the application starts, but it can also send a command to the runtime if you need an effect right at the start.
-- Your `update` function is the only place you will receive messages from the Gren runtime. In addition to updating the model, you can also kick off new commands in response to the messages you receive.
+- Your `update` function is where (and the only place where) you will receive messages from the Gren runtime in response to your commands and subscriptions.
+  In addition to updating the model, you can also kick off new commands in response to the messages you receive.
 - Your `subscriptions` function lets you tell the runtime about certain events you want to receive messages about.
   
 In the next sections you will see what this looks like in practice.

--- a/src/content/docs/applications/runtime.md
+++ b/src/content/docs/applications/runtime.md
@@ -34,7 +34,7 @@ are values representing an effect you want to perform.
 You can think of an effect as something that doesn't conform to the three properties of Gren code described above:
 - It could fail (like reading from local storage or making an HTTP call)
 - It could change something (like writing to the file system or updating a database)
-- It won't _always_ return the same value for the same input (like reading a file or querying a database)
+- It won't _always_ result in the same value (like reading a file or querying a database)
 
 [Subscriptions](https://packages.gren-lang.org/package/gren-lang/core/version/latest/module/Platform.Sub)
 are values that let you tell the Gren runtime that you want to be notified when something happens.

--- a/src/content/docs/applications/runtime.md
+++ b/src/content/docs/applications/runtime.md
@@ -30,7 +30,7 @@ flowchart LR
 ## Commands, Subscriptions, and Messages
 
 [Commands](https://packages.gren-lang.org/package/gren-lang/core/version/latest/module/Platform.Cmd)
-are values representing an effect you want to perform.
+are values representing an _effect_ you want to perform.
 You can think of an effect as something that doesn't conform to the three properties of Gren code described above:
 - It could fail (like reading from local storage or making an HTTP call)
 - It could change something (like writing to the file system or updating a database)

--- a/src/content/docs/applications/runtime.md
+++ b/src/content/docs/applications/runtime.md
@@ -27,4 +27,36 @@ flowchart LR
   runtime <--> external(External\nSystems)
 ``` 
 
+## Commands, Subscriptions, and Messages
+
+[Commands](https://packages.gren-lang.org/package/gren-lang/core/version/latest/module/Platform.Cmd)
+are values representing an effect you want to perform.
+You can think of an effect as something that doesn't conform to the three properties of Gren code described above:
+- It could fail (like reading from local storage or making an HTTP call)
+- It could change something (like writing to the file system or updating a database)
+- It won't _always_ return the same value for the same input (like reading a file or querying a database)
+
+[Subscriptions](https://packages.gren-lang.org/package/gren-lang/core/version/latest/module/Platform.Sub)
+are values that let you tell the Gren runtime that you want to be notified when something happens.
+Like requests to a web server, or a window being resized.
+
+Messages are values the runtime can send back to your application depending on the results of a command, or events on a subscription.
+
+## Interacting with the Gren Runtime
+
+[The Elm Architecture](/book/applications/tea) provides three points for interaction with the Gren runtime:
+
+
+```mermaid
+flowchart LR
+  init -- commands --> runtime(The Gren\nRuntime)
+  update -- commands --> runtime
+  runtime -- messages --> update
+  subscriptions -- subscriptions --> runtime
+```
+
+- Your `init` function initializes your model when the application starts, but it can also send a command to the runtime if you need an effect right at the start.
+- Your `update` function is the only place you will receive messages from the Gren runtime. In addition to updating the model, you can also kick off new commands in response to the messages you receive.
+- Your `subscriptions` lets you tell the runtime about certainjevents you want to receive messages about.
+  
 In the next sections you will see what this looks like in practice.


### PR DESCRIPTION
Talk about commands, subscriptions, and messages and how you interact
with the runtime using TEA.

Moved the TEA section before the runtime since the runtime section now
refers to it.

Here's what the new sections look like:

<img width="745" alt="Screenshot 2025-03-24 at 10 30 31 AM" src="https://github.com/user-attachments/assets/7dead7b4-2b7e-4390-afe3-88c88d6fe290" />
