### PR TITLE
Fixed file extension typo in ports documentation

### DIFF
--- a/src/content/docs/applications/ports.mdx
+++ b/src/content/docs/applications/ports.mdx
@@ -101,7 +101,7 @@ Then define and use your ports in Gren the same way as described in the [browser
 Then compile it with an explicit output target:
 
 ```sh
-gren make src/Main.js --output=main.js
+gren make src/Main.gren --output=main.js
 ```
 
 Giving the target a `.js` extension tells the compiler that you want a module to be included in other javascript instead of a program that runs directly.


### PR DESCRIPTION
Was using the book to brush up on setting up ports and noticed this minor typo!